### PR TITLE
Parameterize the `println` that informs of the fallback cases

### DIFF
--- a/src/pinpointer/core.cljc
+++ b/src/pinpointer/core.cljc
@@ -175,7 +175,7 @@
                  (s/explain-printer ed))
 
              :else (throw traces)))
-     (println "Success!!"))))
+     (println "Success!"))))
 
 (defn pinpoint
   "Given a spec and a value that fails to conform, reports the spec

--- a/src/pinpointer/core.cljc
+++ b/src/pinpointer/core.cljc
@@ -144,8 +144,12 @@
 
   Takes the same options as pinpoint."
   ([ed] (pinpoint-out ed {}))
-  ([ed {:keys [width colorize fallback-on-error eval] :as opts
-        :or {width 70, fallback-on-error true}}]
+  ([ed {:keys [width colorize eval fallback-on-error fallback-reporting-fn] :as opts
+        :or {width 70
+             fallback-on-error true
+             fallback-reporting-fn (fn [_]
+                                     (println (str "[PINPOINTER] Failed to analyze the spec errors, "
+                                                   "and will fall back to s/explain-printer\n")))}}]
    (if ed
      (let [{:keys [::s/problems ::s/value] :as ed'} (correct-paths ed)
            nproblems (count problems)
@@ -171,7 +175,8 @@
                                  ":" (:line caller) ")")))))
 
              fallback-on-error
-             (do (println "[PINPOINTER] Failed to analyze the spec errors, and will fall back to s/explain-printer\n")
+             (do (fallback-reporting-fn {:explain-data ed
+                                         :exception traces})
                  (s/explain-printer ed))
 
              :else (throw traces)))
@@ -190,6 +195,9 @@ The opts map may have the following keys:
   :fallback-on-error - If set to true, falls back to
     s/explain-printer in case of an error during the analysis.
     Otherwise, rethrows the error. Defaults to true.
+  :fallback-reporting-fn - A fn (which takes as an argument a map with `:explanation-data` and `:exception` keys)
+    which reports that pinpointer is falling back to clojure.spec
+   to reports error. Defaults to a println with a fixed message.
   :eval - eval fn to be used to analyze spec errors. Defaults to
     clojure.core/eval in Clojure, nil in ClojureScript."
   ([spec x] (pinpoint spec x {}))


### PR DESCRIPTION
Hi there!

I was finding the `(println "[PINPOINTER] Failed to analyze the spec errors, and will fall back to s/explain-printer\n")` somewhat noisy and with limited usefulness.

This PR leaves up to the user whether to run it (by passing an empty fn), or to actually log the incidence in detail: it can be very handy to access the underlying exception, that way one can try to fix it.

You can try out these changes by raising an error (e.g. `https://github.com/athos/Pinpointer/issues/2`) with the option being passed.

Cheers - Victor