### PR TITLE
Update broken CI settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/clojure:lein-browsers
+      - image: athos/cljc-dev:openjdk-8-alpine-20190219-0
 
     working_directory: ~/repo
 
@@ -25,8 +25,12 @@ jobs:
           key: v1-dependencies-{{ checksum "project.clj" }}
 
       - run:
-          name: test
-          command: lein test-all
+          name: test CLJ
+          command: lein test-clj
+
+      - run:
+          name: test CLJS
+          command: lein test-cljs
 
       - run:
           name: code-coverage

--- a/project.clj
+++ b/project.clj
@@ -23,12 +23,6 @@
                                    :output-dir "target/out"
                                    :main pinpointer.runner
                                    :optimizations :none}}
-                       {:id "nashorn-test"
-                        :source-paths ["src" "test/cljc" "test/cljs"]
-                        :compiler {:output-to "target/nashorn_out/test.js"
-                                   :output-dir "target/nashorn_out"
-                                   :main pinpointer.runner
-                                   :optimizations :whitespace}}
                        {:id "node-test"
                         :source-paths ["src" "test/cljc" "test/cljs"]
                         :compiler {:output-to "target/node_out/test.js"
@@ -44,8 +38,4 @@
 
   :aliases {"test-all" ["do" ["test-clj"] ["test-cljs"]]
             "test-clj" ["eftest"]
-            "test-cljs" ["do" ["test-cljs-none" "once"]
-                              ["test-cljs-nashorn" "once"]]
-            "test-cljs-none" ["doo" "phantom" "test"]
-            "test-cljs-nashorn" ["doo" "nashorn" "nashorn-test"]
-            "test-cljs-node" ["doo" "node" "node-test"]})
+            "test-cljs" ["doo" "node" "node-test" "once"]})


### PR DESCRIPTION
This PR updates the following items:

- Move docker image to [athos/cljc-dev](https://hub.docker.com/r/athos/cljc-dev)
- Drop Nashorn test (since it has already been [deprecated](http://openjdk.java.net/jeps/335))